### PR TITLE
Generalize CMake

### DIFF
--- a/geos_giga/CMakeLists.txt
+++ b/geos_giga/CMakeLists.txt
@@ -1,19 +1,12 @@
-#esma_set_this(OVERRIDE geos_giga)
 esma_set_this()
-
-set (BASEDIR $ENV{BASEDIR})
 
 set (srcs
 GEOS_Giga_InterOp.cc
 )
 
-esma_add_library (${this} 
+esma_add_library (${this}
    SRCS ${srcs}
    )
-include_directories (${this} ${GIGATRAJ_SOURCE_DIR}/include ${BASEDIR}/Linux/include/netcdf)
-target_link_libraries(${this}  gigatraj metsources)
-
-#install (TARGETS ${this} EXPORT ${this}-targets
-#         ARCHIVE DESTINATION lib
-#         LIBRARY DESTINATION lib)
-#INSTALL(EXPORT ${this}-targets DESTINATION lib)
+target_link_libraries (${this} PUBLIC NetCDF::NetCDF_C)
+target_include_directories (${this} PRIVATE ${GIGATRAJ_SOURCE_DIR}/include)
+target_link_libraries(${this} PUBLIC gigatraj metsources)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,7 +1,5 @@
 esma_set_this(OVERRIDE gigatraj)
 
-set (BASEDIR $ENV{BASEDIR})
-
 #add_definitions (-DWRAP_0) # defined in gigatraj.hh
 
 set (srcs
@@ -11,15 +9,13 @@ Earth.cc          MPIGrp.cc           PGenRep.cc      RandomSrc.cc
 FileLock.cc       Parcel.cc           PGenRnd.cc      SerialGrp.cc
 FilePath.cc       ParcelGenerator.cc  PGenRndDisc.cc  Swarm.cc
 Flock.cc          PGenDisc.cc         PlanetNav.cc    trace.cc
-IntegRK4_GEOS.cc 
+IntegRK4_GEOS.cc
 )
 esma_add_subdirectories(filters metsources)
 
-esma_add_library (${this} 
+esma_add_library (${this}
    SRCS ${srcs}
    )
-include_directories (${this} ${GIGATRAJ_SOURCE_DIR}/include ${BASEDIR}/Linux/include/netcdf)
-#install (TARGETS ${this} EXPORT ${this}-targets
-#         ARCHIVE DESTINATION lib
-#         LIBRARY DESTINATION lib)
-#INSTALL(EXPORT ${this}-targets DESTINATION lib)
+
+target_link_libraries(${this} PUBLIC NetCDF::NetCDF_C)
+target_include_directories (${this} PRIVATE ${GIGATRAJ_SOURCE_DIR}/include)

--- a/lib/metsources/CMakeLists.txt
+++ b/lib/metsources/CMakeLists.txt
@@ -12,24 +12,19 @@ GridField.cc              MetGEOSfpFcast.cc     PAltOTF.cc
 GridFieldSfc.cc           MetGEOSPortal.cc      PressOTF.cc
 GridLatLonField3D.cc      MetGridData.cc        ThetaDotOTF.cc
 GridLatLonFieldSfc.cc     MetGridLatLonData.cc  ThetaOTF.cc
-GridCubedSphereField3D.cc 
+GridCubedSphereField3D.cc
 GridCubedSphereFieldSfc.cc
 Hinterp.cc                MetGridSBRot.cc       TropOTF.cc
 LinearVinterp.cc          MetMERRA2.cc          Vinterp.cc
 MetGEOSDistributedData.cc
 MetGEOSDistributedLatLonData.cc
 MetGEOSDistributedCubedData.cc
-) 
+)
 
-set (BASEDIR $ENV{BASEDIR})
 esma_add_library (${this}
     SRCS  ${srcs}
     )
 
-include_directories(${BASEDIR}/Linux/include/netcdf ${GIGATRAJ_SOURCE_DIR}/include)
-
-#target_include_directories (${this} PUBLIC
-#  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-#  $<BUILD_INTERFACE:${GIGATRAJ_SOURCE_DIR}/include>
-#  $<BUILD_INTERFACE:${BASEDIR}/Linux/include/netcdf>)
-target_link_libraries(${this}  MPI::MPI_CXX)
+target_link_libraries (${this} PUBLIC NetCDF::NetCDF_C)
+target_include_directories (${this} PRIVATE ${GIGATRAJ_SOURCE_DIR}/include)
+target_link_libraries(${this} PUBLIC MPI::MPI_CXX)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,14 +1,14 @@
 
-set (BASEDIR $ENV{BASEDIR})
-
 ecbuild_add_executable (
-   TARGET gtmodel_s01.x 
+   TARGET gtmodel_s01.x
    SOURCES gtmodel_s01.cc
    LIBS gigatraj filters metsources)
+target_link_libraries(gtmodel_s01.x PRIVATE NetCDF::NetCDF_C)
+target_include_directories (gtmodel_s01.x PRIVATE ${GIGATRAJ_SOURCE_DIR}/include)
 
 ecbuild_add_executable (
-   TARGET gtmodel_s02.x 
+   TARGET gtmodel_s02.x
    SOURCES gtmodel_s02.cc
    LIBS gigatraj filters metsources)
-
-include_directories (${GIGATRAJ_SOURCE_DIR}/include ${BASEDIR}/Linux/include/netcdf)
+target_link_libraries(gtmodel_s02.x PRIVATE NetCDF::NetCDF_C)
+target_include_directories (gtmodel_s02.x PRIVATE ${GIGATRAJ_SOURCE_DIR}/include)


### PR DESCRIPTION
This PR generalizes the CMake to not have references to `BASEDIR` or anything very-GEOS specific (CMake-wise at least).

Mentioning @weiyuan-jiang so he can test (I can't add as a reviewer as I don't have rights)